### PR TITLE
fix warning

### DIFF
--- a/src/mecab_gyp.cc
+++ b/src/mecab_gyp.cc
@@ -27,7 +27,7 @@ class MecabGyp : public Nan::ObjectWrap {
     if(this->tagger) {
       return this->tagger;
     }
-    this->tagger = tagger = MeCab::createTagger(this->options.c_str());
+    this->tagger = MeCab::createTagger(this->options.c_str());
     return this->tagger;
   }
 


### PR DESCRIPTION
warning fix
```
      01   CXX(target) Release/obj.target/mecab_gyp/src/mecab_gyp.o
      01 ../src/mecab_gyp.cc: In member function ‘MeCab::Tagger* MecabGyp::getTagger()’:
      01 ../src/mecab_gyp.cc:33:18: warning: operation on ‘((MecabGyp*)this)->MecabGyp::tagger’ may be undefined [-Wsequence-point]
      01      this->tagger = tagger = MeCab::createTagger(this->options.c_str());
      01      ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      01   SOLINK_MODULE(target) Release/obj.target/mecab_gyp.node
```